### PR TITLE
fix(tutorials): fix broken css in tutorial 3 in submodule tutorial

### DIFF
--- a/topic03-highlighting.html
+++ b/topic03-highlighting.html
@@ -74,21 +74,30 @@
                 /* Hightlight the second staff in blue */
                 /////////////////////////////////////////
                 else if (choice == 2) {
-                    $(".measure .staff:nth-child(2)" ).attr("fill", "#00e").attr("stroke", "#00e");
+                    // apply attributes to staffs that are siblings of first staff
+                    $(".measure .staff ~ .staff " ).attr("fill", "#00e").attr("stroke", "#00e");
+// remove attributes from staffs that are siblings to second staff
+                    $(".measure .staff ~ .staff ~ .staff " ).attr("fill", "#000").attr("stroke", "#000");
                 }
 
                 //////////////////////////////////////////////////////////
                 /* Hightlight the staffDef of the fourth staff in green */
                 //////////////////////////////////////////////////////////
                 else if (choice == 3) {
-                    $(".measure .staff:nth-child(4) .staffDef" ).attr("fill", "#0c0").attr("stroke", "#0c0");
+                    // apply attributes to staffs that are siblings of second staff
+                    $(".measure .staff ~ .staff ~ .staff .clef, .measure .staff ~ .staff ~ .staff .keySig, .measure .staff ~ .staff ~ .staff .meterSig" ).attr("fill", "#0c0").attr("stroke", "#0c0");
+// remove attributes from staffs that are siblings to third staff
+                    $(".measure .staff ~ .staff ~ .staff ~ .staff .clef, .measure .staff ~ .staff ~ .staff ~ .staff .keySig, .measure .staff ~ .staff ~ .staff ~ .staff .meterSig" ).attr("fill", "#000").attr("stroke", "#000");
                 }
 
                 ///////////////////////////////////////////////////////////////////////////
                 /* Gray out the fourth staff after the fifth measure on the current page */
                 ///////////////////////////////////////////////////////////////////////////
                 else if (choice == 4) {
-                    $(".system .measure:gt(4) .staff:nth-child(4)").attr("fill", "#ccc").attr("stroke", "#ccc");
+                    // apply attributes to staffs that are siblings of third staff
+                    $(".system .measure:gt(4) .staff ~ .staff ~ .staff ~.staff ").attr("fill", "#ccc").attr("stroke", "#ccc");
+// remove attributes from staffs that are siblings to fourth staff
+                    $(".system .measure:gt(4) .staff ~ .staff ~ .staff ~ .staff ~ .staff").attr("fill", "#000").attr("stroke", "#000");
                 }
 
                 else {

--- a/topic03-highlighting.html
+++ b/topic03-highlighting.html
@@ -81,7 +81,7 @@
                 }
 
                 //////////////////////////////////////////////////////////
-                /* Hightlight the staffDef of the fourth staff in green */
+                /* Hightlight the staffDef of the third staff in green */
                 //////////////////////////////////////////////////////////
                 else if (choice == 3) {
                     // apply attributes to staffs that are siblings of second staff


### PR DESCRIPTION
This PR fixes the css for the broken tutorial 3, see rism-ch/verovio#953 and rism-ch/verovio#950.

Trying the PR here and after merging pointing from verovio/gh-pages branch to this commit.